### PR TITLE
Update ubuntu runner

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build_and_publish:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Lint Buildkite plugin


### PR DESCRIPTION
## What does this change?

Following this email from GitHub:

```
The Ubuntu 20.04 runner image will be fully unsupported by April 1, 2025. To raise awareness of the upcoming removal, we will temporarily fail jobs using Ubuntu 20.04. Builds that are scheduled to run during the brownout periods will fail. 
```

We update the runner to `ubuntu-latest`.

## How to test

Does the job run?

## How can we measure success?

Less failing CI jobs!

## Have we considered potential risks?

Risks should be minimal, this only impacts CI.
